### PR TITLE
Add MuZero stock prediction example

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,10 @@
+import pandas as pd
+import yfinance as yf
+
+def download_stock(symbol="AAPL", start="2015-01-01", end="2020-12-31", filename="stock_prices.csv"):
+    data = yf.download(symbol, start=start, end=end)
+    data.to_csv(filename)
+    print(f"Saved {len(data)} rows to {filename}")
+
+if __name__ == "__main__":
+    download_stock()

--- a/muzero_general/games/abstract_game.py
+++ b/muzero_general/games/abstract_game.py
@@ -1,0 +1,105 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractGame(ABC):
+    """
+    Inherit this class for muzero to play
+    """
+
+    @abstractmethod
+    def __init__(self, seed=None):
+        pass
+
+    @abstractmethod
+    def step(self, action):
+        """
+        Apply action to the game.
+
+        Args:
+            action : action of the action_space to take.
+
+        Returns:
+            The new observation, the reward and a boolean if the game has ended.
+        """
+        pass
+
+    def to_play(self):
+        """
+        Return the current player.
+
+        Returns:
+            The current player, it should be an element of the players list in the config.
+        """
+        return 0
+
+    @abstractmethod
+    def legal_actions(self):
+        """
+        Should return the legal actions at each turn, if it is not available, it can return
+        the whole action space. At each turn, the game have to be able to handle one of returned actions.
+
+        For complex game where calculating legal moves is too long, the idea is to define the legal actions
+        equal to the action space but to return a negative reward if the action is illegal.
+
+        Returns:
+            An array of integers, subset of the action space.
+        """
+        pass
+
+    @abstractmethod
+    def reset(self):
+        """
+        Reset the game for a new game.
+
+        Returns:
+            Initial observation of the game.
+        """
+        pass
+
+    def close(self):
+        """
+        Properly close the game.
+        """
+        pass
+
+    @abstractmethod
+    def render(self):
+        """
+        Display the game observation.
+        """
+        pass
+
+    def human_to_action(self):
+        """
+        For multiplayer games, ask the user for a legal action
+        and return the corresponding action number.
+
+        Returns:
+            An integer from the action space.
+        """
+        choice = input(f"Enter the action to play for the player {self.to_play()}: ")
+        while int(choice) not in self.legal_actions():
+            choice = input("Illegal action. Enter another action : ")
+        return int(choice)
+
+    def expert_agent(self):
+        """
+        Hard coded agent that MuZero faces to assess his progress in multiplayer games.
+        It doesn't influence training
+
+        Returns:
+            Action as an integer to take in the current game state
+        """
+        raise NotImplementedError
+
+    def action_to_string(self, action_number):
+        """
+        Convert an action number to a string representing the action.
+
+        Args:
+            action_number: an integer from the action space.
+
+        Returns:
+            String representing the action.
+        """
+        return str(action_number)

--- a/muzero_general/games/stock_market.py
+++ b/muzero_general/games/stock_market.py
@@ -1,0 +1,94 @@
+import numpy as np
+from .abstract_game import AbstractGame
+
+class MuZeroConfig:
+    def __init__(self):
+        self.seed = 0
+        self.max_num_gpus = None
+        self.observation_shape = (1, 1, 1)
+        self.action_space = [0, 1]
+        self.players = [0]
+        self.stacked_observations = 0
+        self.num_workers = 1
+        self.selfplay_on_gpu = False
+        self.max_moves = 200
+        self.num_simulations = 10
+        self.discount = 0.997
+        self.temperature_threshold = None
+        self.root_dirichlet_alpha = 0.25
+        self.root_exploration_fraction = 0.25
+        self.pb_c_base = 19652
+        self.pb_c_init = 1.25
+        self.network = "fullyconnected"
+        self.support_size = 5
+        self.encoding_size = 8
+        self.fc_representation_layers = []
+        self.fc_dynamics_layers = [16]
+        self.fc_reward_layers = [16]
+        self.fc_value_layers = [16]
+        self.fc_policy_layers = [16]
+        import pathlib
+        self.results_path = pathlib.Path(__file__).resolve().parent / "results"
+        self.save_model = True
+        self.training_steps = 100
+        self.batch_size = 32
+        self.checkpoint_interval = 10
+        self.value_loss_weight = 1
+        self.train_on_gpu = False
+        self.optimizer = "Adam"
+        self.weight_decay = 1e-4
+        self.momentum = 0.9
+        self.lr_init = 0.02
+        self.lr_decay_rate = 0.8
+        self.lr_decay_steps = 100
+        self.replay_buffer_size = 50
+        self.num_unroll_steps = 5
+        self.td_steps = 10
+        self.PER = True
+        self.PER_alpha = 0.5
+        self.use_last_model_value = True
+        self.reanalyse_on_gpu = False
+        self.self_play_delay = 0
+        self.training_delay = 0
+        self.ratio = 1.5
+
+    def visit_softmax_temperature_fn(self, trained_steps: int) -> float:
+        return 1.0 if trained_steps < 50 else 0.5
+
+class Game(AbstractGame):
+    def __init__(self, seed=None, data_file="stock_prices.csv"):
+        import pandas as pd
+        self.data = pd.read_csv(data_file)
+        self.prices = self.data["Close"].values
+        self.index = 0
+
+    def step(self, action):
+        if self.index >= len(self.prices) - 2:
+            return self._get_obs(), 0, True
+        current = self.prices[self.index]
+        next_price = self.prices[self.index + 1]
+        diff = next_price - current
+        reward = 1 if (diff > 0 and action == 1) or (diff <= 0 and action == 0) else -1
+        self.index += 1
+        done = self.index >= len(self.prices) - 1
+        return self._get_obs(), reward, done
+
+    def legal_actions(self):
+        return [0, 1]
+
+    def reset(self):
+        self.index = 0
+        return self._get_obs()
+
+    def _get_obs(self):
+        val = self.prices[self.index] if self.index < len(self.prices) else 0.0
+        return np.array([[val]])
+
+    def close(self):
+        pass
+
+    def render(self):
+        pass
+
+    def action_to_string(self, action_number):
+        return {0: "Predict Down", 1: "Predict Up"}[action_number]

--- a/muzero_general/models.py
+++ b/muzero_general/models.py
@@ -1,0 +1,689 @@
+import math
+from abc import ABC, abstractmethod
+
+import torch
+
+
+class MuZeroNetwork:
+    def __new__(cls, config):
+        if config.network == "fullyconnected":
+            return MuZeroFullyConnectedNetwork(
+                config.observation_shape,
+                config.stacked_observations,
+                len(config.action_space),
+                config.encoding_size,
+                config.fc_reward_layers,
+                config.fc_value_layers,
+                config.fc_policy_layers,
+                config.fc_representation_layers,
+                config.fc_dynamics_layers,
+                config.support_size,
+            )
+        elif config.network == "resnet":
+            return MuZeroResidualNetwork(
+                config.observation_shape,
+                config.stacked_observations,
+                len(config.action_space),
+                config.blocks,
+                config.channels,
+                config.reduced_channels_reward,
+                config.reduced_channels_value,
+                config.reduced_channels_policy,
+                config.resnet_fc_reward_layers,
+                config.resnet_fc_value_layers,
+                config.resnet_fc_policy_layers,
+                config.support_size,
+                config.downsample,
+            )
+        else:
+            raise NotImplementedError(
+                'The network parameter should be "fullyconnected" or "resnet".'
+            )
+
+
+def dict_to_cpu(dictionary):
+    cpu_dict = {}
+    for key, value in dictionary.items():
+        if isinstance(value, torch.Tensor):
+            cpu_dict[key] = value.cpu()
+        elif isinstance(value, dict):
+            cpu_dict[key] = dict_to_cpu(value)
+        else:
+            cpu_dict[key] = value
+    return cpu_dict
+
+
+class AbstractNetwork(ABC, torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        pass
+
+    @abstractmethod
+    def initial_inference(self, observation):
+        pass
+
+    @abstractmethod
+    def recurrent_inference(self, encoded_state, action):
+        pass
+
+    def get_weights(self):
+        return dict_to_cpu(self.state_dict())
+
+    def set_weights(self, weights):
+        self.load_state_dict(weights)
+
+
+##################################
+######## Fully Connected #########
+
+
+class MuZeroFullyConnectedNetwork(AbstractNetwork):
+    def __init__(
+        self,
+        observation_shape,
+        stacked_observations,
+        action_space_size,
+        encoding_size,
+        fc_reward_layers,
+        fc_value_layers,
+        fc_policy_layers,
+        fc_representation_layers,
+        fc_dynamics_layers,
+        support_size,
+    ):
+        super().__init__()
+        self.action_space_size = action_space_size
+        self.full_support_size = 2 * support_size + 1
+
+        self.representation_network = torch.nn.DataParallel(
+            mlp(
+                observation_shape[0]
+                * observation_shape[1]
+                * observation_shape[2]
+                * (stacked_observations + 1)
+                + stacked_observations * observation_shape[1] * observation_shape[2],
+                fc_representation_layers,
+                encoding_size,
+            )
+        )
+
+        self.dynamics_encoded_state_network = torch.nn.DataParallel(
+            mlp(
+                encoding_size + self.action_space_size,
+                fc_dynamics_layers,
+                encoding_size,
+            )
+        )
+        self.dynamics_reward_network = torch.nn.DataParallel(
+            mlp(encoding_size, fc_reward_layers, self.full_support_size)
+        )
+
+        self.prediction_policy_network = torch.nn.DataParallel(
+            mlp(encoding_size, fc_policy_layers, self.action_space_size)
+        )
+        self.prediction_value_network = torch.nn.DataParallel(
+            mlp(encoding_size, fc_value_layers, self.full_support_size)
+        )
+
+    def prediction(self, encoded_state):
+        policy_logits = self.prediction_policy_network(encoded_state)
+        value = self.prediction_value_network(encoded_state)
+        return policy_logits, value
+
+    def representation(self, observation):
+        encoded_state = self.representation_network(
+            observation.view(observation.shape[0], -1)
+        )
+        # Scale encoded state between [0, 1] (See appendix paper Training)
+        min_encoded_state = encoded_state.min(1, keepdim=True)[0]
+        max_encoded_state = encoded_state.max(1, keepdim=True)[0]
+        scale_encoded_state = max_encoded_state - min_encoded_state
+        scale_encoded_state[scale_encoded_state < 1e-5] += 1e-5
+        encoded_state_normalized = (
+            encoded_state - min_encoded_state
+        ) / scale_encoded_state
+        return encoded_state_normalized
+
+    def dynamics(self, encoded_state, action):
+        # Stack encoded_state with a game specific one hot encoded action (See paper appendix Network Architecture)
+        action_one_hot = (
+            torch.zeros((action.shape[0], self.action_space_size))
+            .to(action.device)
+            .float()
+        )
+        action_one_hot.scatter_(1, action.long(), 1.0)
+        x = torch.cat((encoded_state, action_one_hot), dim=1)
+
+        next_encoded_state = self.dynamics_encoded_state_network(x)
+
+        reward = self.dynamics_reward_network(next_encoded_state)
+
+        # Scale encoded state between [0, 1] (See paper appendix Training)
+        min_next_encoded_state = next_encoded_state.min(1, keepdim=True)[0]
+        max_next_encoded_state = next_encoded_state.max(1, keepdim=True)[0]
+        scale_next_encoded_state = max_next_encoded_state - min_next_encoded_state
+        scale_next_encoded_state[scale_next_encoded_state < 1e-5] += 1e-5
+        next_encoded_state_normalized = (
+            next_encoded_state - min_next_encoded_state
+        ) / scale_next_encoded_state
+
+        return next_encoded_state_normalized, reward
+
+    def initial_inference(self, observation):
+        encoded_state = self.representation(observation)
+        policy_logits, value = self.prediction(encoded_state)
+        # reward equal to 0 for consistency
+        reward = torch.log(
+            (
+                torch.zeros(1, self.full_support_size)
+                .scatter(1, torch.tensor([[self.full_support_size // 2]]).long(), 1.0)
+                .repeat(len(observation), 1)
+                .to(observation.device)
+            )
+        )
+
+        return (
+            value,
+            reward,
+            policy_logits,
+            encoded_state,
+        )
+
+    def recurrent_inference(self, encoded_state, action):
+        next_encoded_state, reward = self.dynamics(encoded_state, action)
+        policy_logits, value = self.prediction(next_encoded_state)
+        return value, reward, policy_logits, next_encoded_state
+
+
+###### End Fully Connected #######
+##################################
+
+
+##################################
+############# ResNet #############
+
+
+def conv3x3(in_channels, out_channels, stride=1):
+    return torch.nn.Conv2d(
+        in_channels, out_channels, kernel_size=3, stride=stride, padding=1, bias=False
+    )
+
+
+# Residual block
+class ResidualBlock(torch.nn.Module):
+    def __init__(self, num_channels, stride=1):
+        super().__init__()
+        self.conv1 = conv3x3(num_channels, num_channels, stride)
+        self.bn1 = torch.nn.BatchNorm2d(num_channels)
+        self.conv2 = conv3x3(num_channels, num_channels)
+        self.bn2 = torch.nn.BatchNorm2d(num_channels)
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = torch.nn.functional.relu(out)
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out += x
+        out = torch.nn.functional.relu(out)
+        return out
+
+
+# Downsample observations before representation network (See paper appendix Network Architecture)
+class DownSample(torch.nn.Module):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(
+            in_channels,
+            out_channels // 2,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+            bias=False,
+        )
+        self.resblocks1 = torch.nn.ModuleList(
+            [ResidualBlock(out_channels // 2) for _ in range(2)]
+        )
+        self.conv2 = torch.nn.Conv2d(
+            out_channels // 2,
+            out_channels,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+            bias=False,
+        )
+        self.resblocks2 = torch.nn.ModuleList(
+            [ResidualBlock(out_channels) for _ in range(3)]
+        )
+        self.pooling1 = torch.nn.AvgPool2d(kernel_size=3, stride=2, padding=1)
+        self.resblocks3 = torch.nn.ModuleList(
+            [ResidualBlock(out_channels) for _ in range(3)]
+        )
+        self.pooling2 = torch.nn.AvgPool2d(kernel_size=3, stride=2, padding=1)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        for block in self.resblocks1:
+            x = block(x)
+        x = self.conv2(x)
+        for block in self.resblocks2:
+            x = block(x)
+        x = self.pooling1(x)
+        for block in self.resblocks3:
+            x = block(x)
+        x = self.pooling2(x)
+        return x
+
+
+class DownsampleCNN(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, h_w):
+        super().__init__()
+        mid_channels = (in_channels + out_channels) // 2
+        self.features = torch.nn.Sequential(
+            torch.nn.Conv2d(
+                in_channels, mid_channels, kernel_size=h_w[0] * 2, stride=4, padding=2
+            ),
+            torch.nn.ReLU(inplace=True),
+            torch.nn.MaxPool2d(kernel_size=3, stride=2),
+            torch.nn.Conv2d(mid_channels, out_channels, kernel_size=5, padding=2),
+            torch.nn.ReLU(inplace=True),
+            torch.nn.MaxPool2d(kernel_size=3, stride=2),
+        )
+        self.avgpool = torch.nn.AdaptiveAvgPool2d(h_w)
+
+    def forward(self, x):
+        x = self.features(x)
+        x = self.avgpool(x)
+        return x
+
+
+class RepresentationNetwork(torch.nn.Module):
+    def __init__(
+        self,
+        observation_shape,
+        stacked_observations,
+        num_blocks,
+        num_channels,
+        downsample,
+    ):
+        super().__init__()
+        self.downsample = downsample
+        if self.downsample:
+            if self.downsample == "resnet":
+                self.downsample_net = DownSample(
+                    observation_shape[0] * (stacked_observations + 1)
+                    + stacked_observations,
+                    num_channels,
+                )
+            elif self.downsample == "CNN":
+                self.downsample_net = DownsampleCNN(
+                    observation_shape[0] * (stacked_observations + 1)
+                    + stacked_observations,
+                    num_channels,
+                    (
+                        math.ceil(observation_shape[1] / 16),
+                        math.ceil(observation_shape[2] / 16),
+                    ),
+                )
+            else:
+                raise NotImplementedError('downsample should be "resnet" or "CNN".')
+        self.conv = conv3x3(
+            observation_shape[0] * (stacked_observations + 1) + stacked_observations,
+            num_channels,
+        )
+        self.bn = torch.nn.BatchNorm2d(num_channels)
+        self.resblocks = torch.nn.ModuleList(
+            [ResidualBlock(num_channels) for _ in range(num_blocks)]
+        )
+
+    def forward(self, x):
+        if self.downsample:
+            x = self.downsample_net(x)
+        else:
+            x = self.conv(x)
+            x = self.bn(x)
+            x = torch.nn.functional.relu(x)
+
+        for block in self.resblocks:
+            x = block(x)
+        return x
+
+
+class DynamicsNetwork(torch.nn.Module):
+    def __init__(
+        self,
+        num_blocks,
+        num_channels,
+        reduced_channels_reward,
+        fc_reward_layers,
+        full_support_size,
+        block_output_size_reward,
+    ):
+        super().__init__()
+        self.conv = conv3x3(num_channels, num_channels - 1)
+        self.bn = torch.nn.BatchNorm2d(num_channels - 1)
+        self.resblocks = torch.nn.ModuleList(
+            [ResidualBlock(num_channels - 1) for _ in range(num_blocks)]
+        )
+
+        self.conv1x1_reward = torch.nn.Conv2d(
+            num_channels - 1, reduced_channels_reward, 1
+        )
+        self.block_output_size_reward = block_output_size_reward
+        self.fc = mlp(
+            self.block_output_size_reward,
+            fc_reward_layers,
+            full_support_size,
+        )
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        x = torch.nn.functional.relu(x)
+        for block in self.resblocks:
+            x = block(x)
+        state = x
+        x = self.conv1x1_reward(x)
+        x = x.view(-1, self.block_output_size_reward)
+        reward = self.fc(x)
+        return state, reward
+
+
+class PredictionNetwork(torch.nn.Module):
+    def __init__(
+        self,
+        action_space_size,
+        num_blocks,
+        num_channels,
+        reduced_channels_value,
+        reduced_channels_policy,
+        fc_value_layers,
+        fc_policy_layers,
+        full_support_size,
+        block_output_size_value,
+        block_output_size_policy,
+    ):
+        super().__init__()
+        self.resblocks = torch.nn.ModuleList(
+            [ResidualBlock(num_channels) for _ in range(num_blocks)]
+        )
+
+        self.conv1x1_value = torch.nn.Conv2d(num_channels, reduced_channels_value, 1)
+        self.conv1x1_policy = torch.nn.Conv2d(num_channels, reduced_channels_policy, 1)
+        self.block_output_size_value = block_output_size_value
+        self.block_output_size_policy = block_output_size_policy
+        self.fc_value = mlp(
+            self.block_output_size_value, fc_value_layers, full_support_size
+        )
+        self.fc_policy = mlp(
+            self.block_output_size_policy,
+            fc_policy_layers,
+            action_space_size,
+        )
+
+    def forward(self, x):
+        for block in self.resblocks:
+            x = block(x)
+        value = self.conv1x1_value(x)
+        policy = self.conv1x1_policy(x)
+        value = value.view(-1, self.block_output_size_value)
+        policy = policy.view(-1, self.block_output_size_policy)
+        value = self.fc_value(value)
+        policy = self.fc_policy(policy)
+        return policy, value
+
+
+class MuZeroResidualNetwork(AbstractNetwork):
+    def __init__(
+        self,
+        observation_shape,
+        stacked_observations,
+        action_space_size,
+        num_blocks,
+        num_channels,
+        reduced_channels_reward,
+        reduced_channels_value,
+        reduced_channels_policy,
+        fc_reward_layers,
+        fc_value_layers,
+        fc_policy_layers,
+        support_size,
+        downsample,
+    ):
+        super().__init__()
+        self.action_space_size = action_space_size
+        self.full_support_size = 2 * support_size + 1
+        block_output_size_reward = (
+            (
+                reduced_channels_reward
+                * math.ceil(observation_shape[1] / 16)
+                * math.ceil(observation_shape[2] / 16)
+            )
+            if downsample
+            else (reduced_channels_reward * observation_shape[1] * observation_shape[2])
+        )
+
+        block_output_size_value = (
+            (
+                reduced_channels_value
+                * math.ceil(observation_shape[1] / 16)
+                * math.ceil(observation_shape[2] / 16)
+            )
+            if downsample
+            else (reduced_channels_value * observation_shape[1] * observation_shape[2])
+        )
+
+        block_output_size_policy = (
+            (
+                reduced_channels_policy
+                * math.ceil(observation_shape[1] / 16)
+                * math.ceil(observation_shape[2] / 16)
+            )
+            if downsample
+            else (reduced_channels_policy * observation_shape[1] * observation_shape[2])
+        )
+
+        self.representation_network = torch.nn.DataParallel(
+            RepresentationNetwork(
+                observation_shape,
+                stacked_observations,
+                num_blocks,
+                num_channels,
+                downsample,
+            )
+        )
+
+        self.dynamics_network = torch.nn.DataParallel(
+            DynamicsNetwork(
+                num_blocks,
+                num_channels + 1,
+                reduced_channels_reward,
+                fc_reward_layers,
+                self.full_support_size,
+                block_output_size_reward,
+            )
+        )
+
+        self.prediction_network = torch.nn.DataParallel(
+            PredictionNetwork(
+                action_space_size,
+                num_blocks,
+                num_channels,
+                reduced_channels_value,
+                reduced_channels_policy,
+                fc_value_layers,
+                fc_policy_layers,
+                self.full_support_size,
+                block_output_size_value,
+                block_output_size_policy,
+            )
+        )
+
+    def prediction(self, encoded_state):
+        policy, value = self.prediction_network(encoded_state)
+        return policy, value
+
+    def representation(self, observation):
+        encoded_state = self.representation_network(observation)
+
+        # Scale encoded state between [0, 1] (See appendix paper Training)
+        min_encoded_state = (
+            encoded_state.view(
+                -1,
+                encoded_state.shape[1],
+                encoded_state.shape[2] * encoded_state.shape[3],
+            )
+            .min(2, keepdim=True)[0]
+            .unsqueeze(-1)
+        )
+        max_encoded_state = (
+            encoded_state.view(
+                -1,
+                encoded_state.shape[1],
+                encoded_state.shape[2] * encoded_state.shape[3],
+            )
+            .max(2, keepdim=True)[0]
+            .unsqueeze(-1)
+        )
+        scale_encoded_state = max_encoded_state - min_encoded_state
+        scale_encoded_state[scale_encoded_state < 1e-5] += 1e-5
+        encoded_state_normalized = (
+            encoded_state - min_encoded_state
+        ) / scale_encoded_state
+        return encoded_state_normalized
+
+    def dynamics(self, encoded_state, action):
+        # Stack encoded_state with a game specific one hot encoded action (See paper appendix Network Architecture)
+        action_one_hot = (
+            torch.ones(
+                (
+                    encoded_state.shape[0],
+                    1,
+                    encoded_state.shape[2],
+                    encoded_state.shape[3],
+                )
+            )
+            .to(action.device)
+            .float()
+        )
+        action_one_hot = (
+            action[:, :, None, None] * action_one_hot / self.action_space_size
+        )
+        x = torch.cat((encoded_state, action_one_hot), dim=1)
+        next_encoded_state, reward = self.dynamics_network(x)
+
+        # Scale encoded state between [0, 1] (See paper appendix Training)
+        min_next_encoded_state = (
+            next_encoded_state.view(
+                -1,
+                next_encoded_state.shape[1],
+                next_encoded_state.shape[2] * next_encoded_state.shape[3],
+            )
+            .min(2, keepdim=True)[0]
+            .unsqueeze(-1)
+        )
+        max_next_encoded_state = (
+            next_encoded_state.view(
+                -1,
+                next_encoded_state.shape[1],
+                next_encoded_state.shape[2] * next_encoded_state.shape[3],
+            )
+            .max(2, keepdim=True)[0]
+            .unsqueeze(-1)
+        )
+        scale_next_encoded_state = max_next_encoded_state - min_next_encoded_state
+        scale_next_encoded_state[scale_next_encoded_state < 1e-5] += 1e-5
+        next_encoded_state_normalized = (
+            next_encoded_state - min_next_encoded_state
+        ) / scale_next_encoded_state
+        return next_encoded_state_normalized, reward
+
+    def initial_inference(self, observation):
+        encoded_state = self.representation(observation)
+        policy_logits, value = self.prediction(encoded_state)
+        # reward equal to 0 for consistency
+        reward = torch.log(
+            (
+                torch.zeros(1, self.full_support_size)
+                .scatter(1, torch.tensor([[self.full_support_size // 2]]).long(), 1.0)
+                .repeat(len(observation), 1)
+                .to(observation.device)
+            )
+        )
+        return (
+            value,
+            reward,
+            policy_logits,
+            encoded_state,
+        )
+
+    def recurrent_inference(self, encoded_state, action):
+        next_encoded_state, reward = self.dynamics(encoded_state, action)
+        policy_logits, value = self.prediction(next_encoded_state)
+        return value, reward, policy_logits, next_encoded_state
+
+
+########### End ResNet ###########
+##################################
+
+
+def mlp(
+    input_size,
+    layer_sizes,
+    output_size,
+    output_activation=torch.nn.Identity,
+    activation=torch.nn.ELU,
+):
+    sizes = [input_size] + layer_sizes + [output_size]
+    layers = []
+    for i in range(len(sizes) - 1):
+        act = activation if i < len(sizes) - 2 else output_activation
+        layers += [torch.nn.Linear(sizes[i], sizes[i + 1]), act()]
+    return torch.nn.Sequential(*layers)
+
+
+def support_to_scalar(logits, support_size):
+    """
+    Transform a categorical representation to a scalar
+    See paper appendix Network Architecture
+    """
+    # Decode to a scalar
+    probabilities = torch.softmax(logits, dim=1)
+    support = (
+        torch.tensor([x for x in range(-support_size, support_size + 1)])
+        .expand(probabilities.shape)
+        .float()
+        .to(device=probabilities.device)
+    )
+    x = torch.sum(support * probabilities, dim=1, keepdim=True)
+
+    # Invert the scaling (defined in https://arxiv.org/abs/1805.11593)
+    x = torch.sign(x) * (
+        ((torch.sqrt(1 + 4 * 0.001 * (torch.abs(x) + 1 + 0.001)) - 1) / (2 * 0.001))
+        ** 2
+        - 1
+    )
+    return x
+
+
+def scalar_to_support(x, support_size):
+    """
+    Transform a scalar to a categorical representation with (2 * support_size + 1) categories
+    See paper appendix Network Architecture
+    """
+    # Reduce the scale (defined in https://arxiv.org/abs/1805.11593)
+    x = torch.sign(x) * (torch.sqrt(torch.abs(x) + 1) - 1) + 0.001 * x
+
+    # Encode on a vector
+    x = torch.clamp(x, -support_size, support_size)
+    floor = x.floor()
+    prob = x - floor
+    logits = torch.zeros(x.shape[0], x.shape[1], 2 * support_size + 1).to(x.device)
+    logits.scatter_(
+        2, (floor + support_size).long().unsqueeze(-1), (1 - prob).unsqueeze(-1)
+    )
+    indexes = floor + support_size + 1
+    prob = prob.masked_fill_(2 * support_size < indexes, 0.0)
+    indexes = indexes.masked_fill_(2 * support_size < indexes, 0.0)
+    logits.scatter_(2, indexes.long().unsqueeze(-1), prob.unsqueeze(-1))
+    return logits

--- a/muzero_general/muzero.py
+++ b/muzero_general/muzero.py
@@ -1,0 +1,712 @@
+import copy
+import importlib
+import json
+import math
+import pathlib
+import pickle
+import sys
+import time
+
+import nevergrad
+import numpy
+import ray
+import torch
+from torch.utils.tensorboard import SummaryWriter
+
+import diagnose_model
+import models
+import replay_buffer
+import self_play
+import shared_storage
+import trainer
+
+
+class MuZero:
+    """
+    Main class to manage MuZero.
+
+    Args:
+        game_name (str): Name of the game module, it should match the name of a .py file
+        in the "./games" directory.
+
+        config (dict, MuZeroConfig, optional): Override the default config of the game.
+
+        split_resources_in (int, optional): Split the GPU usage when using concurent muzero instances.
+
+    Example:
+        >>> muzero = MuZero("cartpole")
+        >>> muzero.train()
+        >>> muzero.test(render=True)
+    """
+
+    def __init__(self, game_name, config=None, split_resources_in=1):
+        # Load the game and the config from the module with the game name
+        try:
+            game_module = importlib.import_module("games." + game_name)
+            self.Game = game_module.Game
+            self.config = game_module.MuZeroConfig()
+        except ModuleNotFoundError as err:
+            print(
+                f'{game_name} is not a supported game name, try "cartpole" or refer to the documentation for adding a new game.'
+            )
+            raise err
+
+        # Overwrite the config
+        if config:
+            if type(config) is dict:
+                for param, value in config.items():
+                    if hasattr(self.config, param):
+                        setattr(self.config, param, value)
+                    else:
+                        raise AttributeError(
+                            f"{game_name} config has no attribute '{param}'. Check the config file for the complete list of parameters."
+                        )
+            else:
+                self.config = config
+
+        # Fix random generator seed
+        numpy.random.seed(self.config.seed)
+        torch.manual_seed(self.config.seed)
+
+        # Manage GPUs
+        if self.config.max_num_gpus == 0 and (
+            self.config.selfplay_on_gpu
+            or self.config.train_on_gpu
+            or self.config.reanalyse_on_gpu
+        ):
+            raise ValueError(
+                "Inconsistent MuZeroConfig: max_num_gpus = 0 but GPU requested by selfplay_on_gpu or train_on_gpu or reanalyse_on_gpu."
+            )
+        if (
+            self.config.selfplay_on_gpu
+            or self.config.train_on_gpu
+            or self.config.reanalyse_on_gpu
+        ):
+            total_gpus = (
+                self.config.max_num_gpus
+                if self.config.max_num_gpus is not None
+                else torch.cuda.device_count()
+            )
+        else:
+            total_gpus = 0
+        self.num_gpus = total_gpus / split_resources_in
+        if 1 < self.num_gpus:
+            self.num_gpus = math.floor(self.num_gpus)
+
+        ray.init(num_gpus=total_gpus, ignore_reinit_error=True)
+
+        # Checkpoint and replay buffer used to initialize workers
+        self.checkpoint = {
+            "weights": None,
+            "optimizer_state": None,
+            "total_reward": 0,
+            "muzero_reward": 0,
+            "opponent_reward": 0,
+            "episode_length": 0,
+            "mean_value": 0,
+            "training_step": 0,
+            "lr": 0,
+            "total_loss": 0,
+            "value_loss": 0,
+            "reward_loss": 0,
+            "policy_loss": 0,
+            "num_played_games": 0,
+            "num_played_steps": 0,
+            "num_reanalysed_games": 0,
+            "terminate": False,
+        }
+        self.replay_buffer = {}
+
+        cpu_actor = CPUActor.remote()
+        cpu_weights = cpu_actor.get_initial_weights.remote(self.config)
+        self.checkpoint["weights"], self.summary = copy.deepcopy(ray.get(cpu_weights))
+
+        # Workers
+        self.self_play_workers = None
+        self.test_worker = None
+        self.training_worker = None
+        self.reanalyse_worker = None
+        self.replay_buffer_worker = None
+        self.shared_storage_worker = None
+
+    def train(self, log_in_tensorboard=True):
+        """
+        Spawn ray workers and launch the training.
+
+        Args:
+            log_in_tensorboard (bool): Start a testing worker and log its performance in TensorBoard.
+        """
+        if log_in_tensorboard or self.config.save_model:
+            self.config.results_path.mkdir(parents=True, exist_ok=True)
+
+        # Manage GPUs
+        if 0 < self.num_gpus:
+            num_gpus_per_worker = self.num_gpus / (
+                self.config.train_on_gpu
+                + self.config.num_workers * self.config.selfplay_on_gpu
+                + log_in_tensorboard * self.config.selfplay_on_gpu
+                + self.config.use_last_model_value * self.config.reanalyse_on_gpu
+            )
+            if 1 < num_gpus_per_worker:
+                num_gpus_per_worker = math.floor(num_gpus_per_worker)
+        else:
+            num_gpus_per_worker = 0
+
+        # Initialize workers
+        self.training_worker = trainer.Trainer.options(
+            num_cpus=0,
+            num_gpus=num_gpus_per_worker if self.config.train_on_gpu else 0,
+        ).remote(self.checkpoint, self.config)
+
+        self.shared_storage_worker = shared_storage.SharedStorage.remote(
+            self.checkpoint,
+            self.config,
+        )
+        self.shared_storage_worker.set_info.remote("terminate", False)
+
+        self.replay_buffer_worker = replay_buffer.ReplayBuffer.remote(
+            self.checkpoint, self.replay_buffer, self.config
+        )
+
+        if self.config.use_last_model_value:
+            self.reanalyse_worker = replay_buffer.Reanalyse.options(
+                num_cpus=0,
+                num_gpus=num_gpus_per_worker if self.config.reanalyse_on_gpu else 0,
+            ).remote(self.checkpoint, self.config)
+
+        self.self_play_workers = [
+            self_play.SelfPlay.options(
+                num_cpus=0,
+                num_gpus=num_gpus_per_worker if self.config.selfplay_on_gpu else 0,
+            ).remote(
+                self.checkpoint,
+                self.Game,
+                self.config,
+                self.config.seed + seed,
+            )
+            for seed in range(self.config.num_workers)
+        ]
+
+        # Launch workers
+        [
+            self_play_worker.continuous_self_play.remote(
+                self.shared_storage_worker, self.replay_buffer_worker
+            )
+            for self_play_worker in self.self_play_workers
+        ]
+        self.training_worker.continuous_update_weights.remote(
+            self.replay_buffer_worker, self.shared_storage_worker
+        )
+        if self.config.use_last_model_value:
+            self.reanalyse_worker.reanalyse.remote(
+                self.replay_buffer_worker, self.shared_storage_worker
+            )
+
+        if log_in_tensorboard:
+            self.logging_loop(
+                num_gpus_per_worker if self.config.selfplay_on_gpu else 0,
+            )
+
+    def logging_loop(self, num_gpus):
+        """
+        Keep track of the training performance.
+        """
+        # Launch the test worker to get performance metrics
+        self.test_worker = self_play.SelfPlay.options(
+            num_cpus=0,
+            num_gpus=num_gpus,
+        ).remote(
+            self.checkpoint,
+            self.Game,
+            self.config,
+            self.config.seed + self.config.num_workers,
+        )
+        self.test_worker.continuous_self_play.remote(
+            self.shared_storage_worker, None, True
+        )
+
+        # Write everything in TensorBoard
+        writer = SummaryWriter(self.config.results_path)
+
+        print(
+            "\nTraining...\nRun tensorboard --logdir ./results and go to http://localhost:6006/ to see in real time the training performance.\n"
+        )
+
+        # Save hyperparameters to TensorBoard
+        hp_table = [
+            f"| {key} | {value} |" for key, value in self.config.__dict__.items()
+        ]
+        writer.add_text(
+            "Hyperparameters",
+            "| Parameter | Value |\n|-------|-------|\n" + "\n".join(hp_table),
+        )
+        # Save model representation
+        writer.add_text(
+            "Model summary",
+            self.summary,
+        )
+        # Loop for updating the training performance
+        counter = 0
+        keys = [
+            "total_reward",
+            "muzero_reward",
+            "opponent_reward",
+            "episode_length",
+            "mean_value",
+            "training_step",
+            "lr",
+            "total_loss",
+            "value_loss",
+            "reward_loss",
+            "policy_loss",
+            "num_played_games",
+            "num_played_steps",
+            "num_reanalysed_games",
+        ]
+        info = ray.get(self.shared_storage_worker.get_info.remote(keys))
+        try:
+            while info["training_step"] < self.config.training_steps:
+                info = ray.get(self.shared_storage_worker.get_info.remote(keys))
+                writer.add_scalar(
+                    "1.Total_reward/1.Total_reward",
+                    info["total_reward"],
+                    counter,
+                )
+                writer.add_scalar(
+                    "1.Total_reward/2.Mean_value",
+                    info["mean_value"],
+                    counter,
+                )
+                writer.add_scalar(
+                    "1.Total_reward/3.Episode_length",
+                    info["episode_length"],
+                    counter,
+                )
+                writer.add_scalar(
+                    "1.Total_reward/4.MuZero_reward",
+                    info["muzero_reward"],
+                    counter,
+                )
+                writer.add_scalar(
+                    "1.Total_reward/5.Opponent_reward",
+                    info["opponent_reward"],
+                    counter,
+                )
+                writer.add_scalar(
+                    "2.Workers/1.Self_played_games",
+                    info["num_played_games"],
+                    counter,
+                )
+                writer.add_scalar(
+                    "2.Workers/2.Training_steps", info["training_step"], counter
+                )
+                writer.add_scalar(
+                    "2.Workers/3.Self_played_steps", info["num_played_steps"], counter
+                )
+                writer.add_scalar(
+                    "2.Workers/4.Reanalysed_games",
+                    info["num_reanalysed_games"],
+                    counter,
+                )
+                writer.add_scalar(
+                    "2.Workers/5.Training_steps_per_self_played_step_ratio",
+                    info["training_step"] / max(1, info["num_played_steps"]),
+                    counter,
+                )
+                writer.add_scalar("2.Workers/6.Learning_rate", info["lr"], counter)
+                writer.add_scalar(
+                    "3.Loss/1.Total_weighted_loss", info["total_loss"], counter
+                )
+                writer.add_scalar("3.Loss/Value_loss", info["value_loss"], counter)
+                writer.add_scalar("3.Loss/Reward_loss", info["reward_loss"], counter)
+                writer.add_scalar("3.Loss/Policy_loss", info["policy_loss"], counter)
+                print(
+                    f'Last test reward: {info["total_reward"]:.2f}. Training step: {info["training_step"]}/{self.config.training_steps}. Played games: {info["num_played_games"]}. Loss: {info["total_loss"]:.2f}',
+                    end="\r",
+                )
+                counter += 1
+                time.sleep(0.5)
+        except KeyboardInterrupt:
+            pass
+
+        self.terminate_workers()
+
+        if self.config.save_model:
+            # Persist replay buffer to disk
+            path = self.config.results_path / "replay_buffer.pkl"
+            print(f"\n\nPersisting replay buffer games to disk at {path}")
+            pickle.dump(
+                {
+                    "buffer": self.replay_buffer,
+                    "num_played_games": self.checkpoint["num_played_games"],
+                    "num_played_steps": self.checkpoint["num_played_steps"],
+                    "num_reanalysed_games": self.checkpoint["num_reanalysed_games"],
+                },
+                open(path, "wb"),
+            )
+
+    def terminate_workers(self):
+        """
+        Softly terminate the running tasks and garbage collect the workers.
+        """
+        if self.shared_storage_worker:
+            self.shared_storage_worker.set_info.remote("terminate", True)
+            self.checkpoint = ray.get(
+                self.shared_storage_worker.get_checkpoint.remote()
+            )
+        if self.replay_buffer_worker:
+            self.replay_buffer = ray.get(self.replay_buffer_worker.get_buffer.remote())
+
+        print("\nShutting down workers...")
+
+        self.self_play_workers = None
+        self.test_worker = None
+        self.training_worker = None
+        self.reanalyse_worker = None
+        self.replay_buffer_worker = None
+        self.shared_storage_worker = None
+
+    def test(
+        self, render=True, opponent=None, muzero_player=None, num_tests=1, num_gpus=0
+    ):
+        """
+        Test the model in a dedicated thread.
+
+        Args:
+            render (bool): To display or not the environment. Defaults to True.
+
+            opponent (str): "self" for self-play, "human" for playing against MuZero and "random"
+            for a random agent, None will use the opponent in the config. Defaults to None.
+
+            muzero_player (int): Player number of MuZero in case of multiplayer
+            games, None let MuZero play all players turn by turn, None will use muzero_player in
+            the config. Defaults to None.
+
+            num_tests (int): Number of games to average. Defaults to 1.
+
+            num_gpus (int): Number of GPUs to use, 0 forces to use the CPU. Defaults to 0.
+        """
+        opponent = opponent if opponent else self.config.opponent
+        muzero_player = muzero_player if muzero_player else self.config.muzero_player
+        self_play_worker = self_play.SelfPlay.options(
+            num_cpus=0,
+            num_gpus=num_gpus,
+        ).remote(self.checkpoint, self.Game, self.config, numpy.random.randint(10000))
+        results = []
+        for i in range(num_tests):
+            print(f"Testing {i+1}/{num_tests}")
+            results.append(
+                ray.get(
+                    self_play_worker.play_game.remote(
+                        0,
+                        0,
+                        render,
+                        opponent,
+                        muzero_player,
+                    )
+                )
+            )
+        self_play_worker.close_game.remote()
+
+        if len(self.config.players) == 1:
+            result = numpy.mean([sum(history.reward_history) for history in results])
+        else:
+            result = numpy.mean(
+                [
+                    sum(
+                        reward
+                        for i, reward in enumerate(history.reward_history)
+                        if history.to_play_history[i - 1] == muzero_player
+                    )
+                    for history in results
+                ]
+            )
+        return result
+
+    def load_model(self, checkpoint_path=None, replay_buffer_path=None):
+        """
+        Load a model and/or a saved replay buffer.
+
+        Args:
+            checkpoint_path (str): Path to model.checkpoint or model.weights.
+
+            replay_buffer_path (str): Path to replay_buffer.pkl
+        """
+        # Load checkpoint
+        if checkpoint_path:
+            checkpoint_path = pathlib.Path(checkpoint_path)
+            self.checkpoint = torch.load(checkpoint_path)
+            print(f"\nUsing checkpoint from {checkpoint_path}")
+
+        # Load replay buffer
+        if replay_buffer_path:
+            replay_buffer_path = pathlib.Path(replay_buffer_path)
+            with open(replay_buffer_path, "rb") as f:
+                replay_buffer_infos = pickle.load(f)
+            self.replay_buffer = replay_buffer_infos["buffer"]
+            self.checkpoint["num_played_steps"] = replay_buffer_infos[
+                "num_played_steps"
+            ]
+            self.checkpoint["num_played_games"] = replay_buffer_infos[
+                "num_played_games"
+            ]
+            self.checkpoint["num_reanalysed_games"] = replay_buffer_infos[
+                "num_reanalysed_games"
+            ]
+
+            print(f"\nInitializing replay buffer with {replay_buffer_path}")
+        else:
+            print(f"Using empty buffer.")
+            self.replay_buffer = {}
+            self.checkpoint["training_step"] = 0
+            self.checkpoint["num_played_steps"] = 0
+            self.checkpoint["num_played_games"] = 0
+            self.checkpoint["num_reanalysed_games"] = 0
+
+    def diagnose_model(self, horizon):
+        """
+        Play a game only with the learned model then play the same trajectory in the real
+        environment and display information.
+
+        Args:
+            horizon (int): Number of timesteps for which we collect information.
+        """
+        game = self.Game(self.config.seed)
+        obs = game.reset()
+        dm = diagnose_model.DiagnoseModel(self.checkpoint, self.config)
+        dm.compare_virtual_with_real_trajectories(obs, game, horizon)
+        input("Press enter to close all plots")
+        dm.close_all()
+
+
+@ray.remote(num_cpus=0, num_gpus=0)
+class CPUActor:
+    # Trick to force DataParallel to stay on CPU to get weights on CPU even if there is a GPU
+    def __init__(self):
+        pass
+
+    def get_initial_weights(self, config):
+        model = models.MuZeroNetwork(config)
+        weigths = model.get_weights()
+        summary = str(model).replace("\n", " \n\n")
+        return weigths, summary
+
+
+def hyperparameter_search(
+    game_name, parametrization, budget, parallel_experiments, num_tests
+):
+    """
+    Search for hyperparameters by launching parallel experiments.
+
+    Args:
+        game_name (str): Name of the game module, it should match the name of a .py file
+        in the "./games" directory.
+
+        parametrization : Nevergrad parametrization, please refer to nevergrad documentation.
+
+        budget (int): Number of experiments to launch in total.
+
+        parallel_experiments (int): Number of experiments to launch in parallel.
+
+        num_tests (int): Number of games to average for evaluating an experiment.
+    """
+    optimizer = nevergrad.optimizers.OnePlusOne(
+        parametrization=parametrization, budget=budget
+    )
+
+    running_experiments = []
+    best_training = None
+    try:
+        # Launch initial experiments
+        for i in range(parallel_experiments):
+            if 0 < budget:
+                param = optimizer.ask()
+                print(f"Launching new experiment: {param.value}")
+                muzero = MuZero(game_name, param.value, parallel_experiments)
+                muzero.param = param
+                muzero.train(False)
+                running_experiments.append(muzero)
+                budget -= 1
+
+        while 0 < budget or any(running_experiments):
+            for i, experiment in enumerate(running_experiments):
+                if experiment and experiment.config.training_steps <= ray.get(
+                    experiment.shared_storage_worker.get_info.remote("training_step")
+                ):
+                    experiment.terminate_workers()
+                    result = experiment.test(False, num_tests=num_tests)
+                    if not best_training or best_training["result"] < result:
+                        best_training = {
+                            "result": result,
+                            "config": experiment.config,
+                            "checkpoint": experiment.checkpoint,
+                        }
+                    print(f"Parameters: {experiment.param.value}")
+                    print(f"Result: {result}")
+                    optimizer.tell(experiment.param, -result)
+
+                    if 0 < budget:
+                        param = optimizer.ask()
+                        print(f"Launching new experiment: {param.value}")
+                        muzero = MuZero(game_name, param.value, parallel_experiments)
+                        muzero.param = param
+                        muzero.train(False)
+                        running_experiments[i] = muzero
+                        budget -= 1
+                    else:
+                        running_experiments[i] = None
+
+    except KeyboardInterrupt:
+        for experiment in running_experiments:
+            if isinstance(experiment, MuZero):
+                experiment.terminate_workers()
+
+    recommendation = optimizer.provide_recommendation()
+    print("Best hyperparameters:")
+    print(recommendation.value)
+    if best_training:
+        # Save best training weights (but it's not the recommended weights)
+        best_training["config"].results_path.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            best_training["checkpoint"],
+            best_training["config"].results_path / "model.checkpoint",
+        )
+        # Save the recommended hyperparameters
+        text_file = open(
+            best_training["config"].results_path / "best_parameters.txt",
+            "w",
+        )
+        text_file.write(str(recommendation.value))
+        text_file.close()
+    return recommendation.value
+
+
+def load_model_menu(muzero, game_name):
+    # Configure running options
+    options = ["Specify paths manually"] + sorted(
+        (pathlib.Path("results") / game_name).glob("*/")
+    )
+    options.reverse()
+    print()
+    for i in range(len(options)):
+        print(f"{i}. {options[i]}")
+
+    choice = input("Enter a number to choose a model to load: ")
+    valid_inputs = [str(i) for i in range(len(options))]
+    while choice not in valid_inputs:
+        choice = input("Invalid input, enter a number listed above: ")
+    choice = int(choice)
+
+    if choice == (len(options) - 1):
+        # manual path option
+        checkpoint_path = input(
+            "Enter a path to the model.checkpoint, or ENTER if none: "
+        )
+        while checkpoint_path and not pathlib.Path(checkpoint_path).is_file():
+            checkpoint_path = input("Invalid checkpoint path. Try again: ")
+        replay_buffer_path = input(
+            "Enter a path to the replay_buffer.pkl, or ENTER if none: "
+        )
+        while replay_buffer_path and not pathlib.Path(replay_buffer_path).is_file():
+            replay_buffer_path = input("Invalid replay buffer path. Try again: ")
+    else:
+        checkpoint_path = options[choice] / "model.checkpoint"
+        replay_buffer_path = options[choice] / "replay_buffer.pkl"
+
+    muzero.load_model(
+        checkpoint_path=checkpoint_path,
+        replay_buffer_path=replay_buffer_path,
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        # Train directly with: python muzero.py cartpole
+        muzero = MuZero(sys.argv[1])
+        muzero.train()
+    elif len(sys.argv) == 3:
+        # Train directly with: python muzero.py cartpole '{"lr_init": 0.01}'
+        config = json.loads(sys.argv[2])
+        muzero = MuZero(sys.argv[1], config)
+        muzero.train()
+    else:
+        print("\nWelcome to MuZero! Here's a list of games:")
+        # Let user pick a game
+        games = [
+            filename.stem
+            for filename in sorted(list((pathlib.Path.cwd() / "games").glob("*.py")))
+            if filename.name != "abstract_game.py"
+        ]
+        for i in range(len(games)):
+            print(f"{i}. {games[i]}")
+        choice = input("Enter a number to choose the game: ")
+        valid_inputs = [str(i) for i in range(len(games))]
+        while choice not in valid_inputs:
+            choice = input("Invalid input, enter a number listed above: ")
+
+        # Initialize MuZero
+        choice = int(choice)
+        game_name = games[choice]
+        muzero = MuZero(game_name)
+
+        while True:
+            # Configure running options
+            options = [
+                "Train",
+                "Load pretrained model",
+                "Diagnose model",
+                "Render some self play games",
+                "Play against MuZero",
+                "Test the game manually",
+                "Hyperparameter search",
+                "Exit",
+            ]
+            print()
+            for i in range(len(options)):
+                print(f"{i}. {options[i]}")
+
+            choice = input("Enter a number to choose an action: ")
+            valid_inputs = [str(i) for i in range(len(options))]
+            while choice not in valid_inputs:
+                choice = input("Invalid input, enter a number listed above: ")
+            choice = int(choice)
+            if choice == 0:
+                muzero.train()
+            elif choice == 1:
+                load_model_menu(muzero, game_name)
+            elif choice == 2:
+                muzero.diagnose_model(30)
+            elif choice == 3:
+                muzero.test(render=True, opponent="self", muzero_player=None)
+            elif choice == 4:
+                muzero.test(render=True, opponent="human", muzero_player=0)
+            elif choice == 5:
+                env = muzero.Game()
+                env.reset()
+                env.render()
+
+                done = False
+                while not done:
+                    action = env.human_to_action()
+                    observation, reward, done = env.step(action)
+                    print(f"\nAction: {env.action_to_string(action)}\nReward: {reward}")
+                    env.render()
+            elif choice == 6:
+                # Define here the parameters to tune
+                # Parametrization documentation: https://facebookresearch.github.io/nevergrad/parametrization.html
+                muzero.terminate_workers()
+                del muzero
+                budget = 20
+                parallel_experiments = 2
+                lr_init = nevergrad.p.Log(lower=0.0001, upper=0.1)
+                discount = nevergrad.p.Log(lower=0.95, upper=0.9999)
+                parametrization = nevergrad.p.Dict(lr_init=lr_init, discount=discount)
+                best_hyperparameters = hyperparameter_search(
+                    game_name, parametrization, budget, parallel_experiments, 20
+                )
+                muzero = MuZero(game_name, best_hyperparameters)
+            else:
+                break
+            print("\nDone")
+
+    ray.shutdown()

--- a/muzero_general/replay_buffer.py
+++ b/muzero_general/replay_buffer.py
@@ -1,0 +1,373 @@
+import copy
+import time
+
+import numpy
+import ray
+import torch
+
+import models
+
+
+@ray.remote
+class ReplayBuffer:
+    """
+    Class which run in a dedicated thread to store played games and generate batch.
+    """
+
+    def __init__(self, initial_checkpoint, initial_buffer, config):
+        self.config = config
+        self.buffer = copy.deepcopy(initial_buffer)
+        self.num_played_games = initial_checkpoint["num_played_games"]
+        self.num_played_steps = initial_checkpoint["num_played_steps"]
+        self.total_samples = sum(
+            [len(game_history.root_values) for game_history in self.buffer.values()]
+        )
+        if self.total_samples != 0:
+            print(
+                f"Replay buffer initialized with {self.total_samples} samples ({self.num_played_games} games).\n"
+            )
+
+        # Fix random generator seed
+        numpy.random.seed(self.config.seed)
+
+    def save_game(self, game_history, shared_storage=None):
+        if self.config.PER:
+            if game_history.priorities is not None:
+                # Avoid read only array when loading replay buffer from disk
+                game_history.priorities = numpy.copy(game_history.priorities)
+            else:
+                # Initial priorities for the prioritized replay (See paper appendix Training)
+                priorities = []
+                for i, root_value in enumerate(game_history.root_values):
+                    priority = (
+                        numpy.abs(
+                            root_value - self.compute_target_value(game_history, i)
+                        )
+                        ** self.config.PER_alpha
+                    )
+                    priorities.append(priority)
+
+                game_history.priorities = numpy.array(priorities, dtype="float32")
+                game_history.game_priority = numpy.max(game_history.priorities)
+
+        self.buffer[self.num_played_games] = game_history
+        self.num_played_games += 1
+        self.num_played_steps += len(game_history.root_values)
+        self.total_samples += len(game_history.root_values)
+
+        if self.config.replay_buffer_size < len(self.buffer):
+            del_id = self.num_played_games - len(self.buffer)
+            self.total_samples -= len(self.buffer[del_id].root_values)
+            del self.buffer[del_id]
+
+        if shared_storage:
+            shared_storage.set_info.remote("num_played_games", self.num_played_games)
+            shared_storage.set_info.remote("num_played_steps", self.num_played_steps)
+
+    def get_buffer(self):
+        return self.buffer
+
+    def get_batch(self):
+        (
+            index_batch,
+            observation_batch,
+            action_batch,
+            reward_batch,
+            value_batch,
+            policy_batch,
+            gradient_scale_batch,
+        ) = ([], [], [], [], [], [], [])
+        weight_batch = [] if self.config.PER else None
+
+        for game_id, game_history, game_prob in self.sample_n_games(
+            self.config.batch_size
+        ):
+            game_pos, pos_prob = self.sample_position(game_history)
+
+            values, rewards, policies, actions = self.make_target(
+                game_history, game_pos
+            )
+
+            index_batch.append([game_id, game_pos])
+            observation_batch.append(
+                game_history.get_stacked_observations(
+                    game_pos,
+                    self.config.stacked_observations,
+                    len(self.config.action_space),
+                )
+            )
+            action_batch.append(actions)
+            value_batch.append(values)
+            reward_batch.append(rewards)
+            policy_batch.append(policies)
+            gradient_scale_batch.append(
+                [
+                    min(
+                        self.config.num_unroll_steps,
+                        len(game_history.action_history) - game_pos,
+                    )
+                ]
+                * len(actions)
+            )
+            if self.config.PER:
+                weight_batch.append(1 / (self.total_samples * game_prob * pos_prob))
+
+        if self.config.PER:
+            weight_batch = numpy.array(weight_batch, dtype="float32") / max(
+                weight_batch
+            )
+
+        # observation_batch: batch, channels, height, width
+        # action_batch: batch, num_unroll_steps+1
+        # value_batch: batch, num_unroll_steps+1
+        # reward_batch: batch, num_unroll_steps+1
+        # policy_batch: batch, num_unroll_steps+1, len(action_space)
+        # weight_batch: batch
+        # gradient_scale_batch: batch, num_unroll_steps+1
+        return (
+            index_batch,
+            (
+                observation_batch,
+                action_batch,
+                value_batch,
+                reward_batch,
+                policy_batch,
+                weight_batch,
+                gradient_scale_batch,
+            ),
+        )
+
+    def sample_game(self, force_uniform=False):
+        """
+        Sample game from buffer either uniformly or according to some priority.
+        See paper appendix Training.
+        """
+        game_prob = None
+        if self.config.PER and not force_uniform:
+            game_probs = numpy.array(
+                [game_history.game_priority for game_history in self.buffer.values()],
+                dtype="float32",
+            )
+            game_probs /= numpy.sum(game_probs)
+            game_index = numpy.random.choice(len(self.buffer), p=game_probs)
+            game_prob = game_probs[game_index]
+        else:
+            game_index = numpy.random.choice(len(self.buffer))
+        game_id = self.num_played_games - len(self.buffer) + game_index
+
+        return game_id, self.buffer[game_id], game_prob
+
+    def sample_n_games(self, n_games, force_uniform=False):
+        if self.config.PER and not force_uniform:
+            game_id_list = []
+            game_probs = []
+            for game_id, game_history in self.buffer.items():
+                game_id_list.append(game_id)
+                game_probs.append(game_history.game_priority)
+            game_probs = numpy.array(game_probs, dtype="float32")
+            game_probs /= numpy.sum(game_probs)
+            game_prob_dict = dict(
+                [(game_id, prob) for game_id, prob in zip(game_id_list, game_probs)]
+            )
+            selected_games = numpy.random.choice(game_id_list, n_games, p=game_probs)
+        else:
+            selected_games = numpy.random.choice(list(self.buffer.keys()), n_games)
+            game_prob_dict = {}
+        ret = [
+            (game_id, self.buffer[game_id], game_prob_dict.get(game_id))
+            for game_id in selected_games
+        ]
+        return ret
+
+    def sample_position(self, game_history, force_uniform=False):
+        """
+        Sample position from game either uniformly or according to some priority.
+        See paper appendix Training.
+        """
+        position_prob = None
+        if self.config.PER and not force_uniform:
+            position_probs = game_history.priorities / sum(game_history.priorities)
+            position_index = numpy.random.choice(len(position_probs), p=position_probs)
+            position_prob = position_probs[position_index]
+        else:
+            position_index = numpy.random.choice(len(game_history.root_values))
+
+        return position_index, position_prob
+
+    def update_game_history(self, game_id, game_history):
+        # The element could have been removed since its selection and update
+        if next(iter(self.buffer)) <= game_id:
+            if self.config.PER:
+                # Avoid read only array when loading replay buffer from disk
+                game_history.priorities = numpy.copy(game_history.priorities)
+            self.buffer[game_id] = game_history
+
+    def update_priorities(self, priorities, index_info):
+        """
+        Update game and position priorities with priorities calculated during the training.
+        See Distributed Prioritized Experience Replay https://arxiv.org/abs/1803.00933
+        """
+        for i in range(len(index_info)):
+            game_id, game_pos = index_info[i]
+
+            # The element could have been removed since its selection and training
+            if next(iter(self.buffer)) <= game_id:
+                # Update position priorities
+                priority = priorities[i, :]
+                start_index = game_pos
+                end_index = min(
+                    game_pos + len(priority), len(self.buffer[game_id].priorities)
+                )
+                self.buffer[game_id].priorities[start_index:end_index] = priority[
+                    : end_index - start_index
+                ]
+
+                # Update game priorities
+                self.buffer[game_id].game_priority = numpy.max(
+                    self.buffer[game_id].priorities
+                )
+
+    def compute_target_value(self, game_history, index):
+        # The value target is the discounted root value of the search tree td_steps into the
+        # future, plus the discounted sum of all rewards until then.
+        bootstrap_index = index + self.config.td_steps
+        if bootstrap_index < len(game_history.root_values):
+            root_values = (
+                game_history.root_values
+                if game_history.reanalysed_predicted_root_values is None
+                else game_history.reanalysed_predicted_root_values
+            )
+            last_step_value = (
+                root_values[bootstrap_index]
+                if game_history.to_play_history[bootstrap_index]
+                == game_history.to_play_history[index]
+                else -root_values[bootstrap_index]
+            )
+
+            value = last_step_value * self.config.discount**self.config.td_steps
+        else:
+            value = 0
+
+        for i, reward in enumerate(
+            game_history.reward_history[index + 1 : bootstrap_index + 1]
+        ):
+            # The value is oriented from the perspective of the current player
+            value += (
+                reward
+                if game_history.to_play_history[index]
+                == game_history.to_play_history[index + i]
+                else -reward
+            ) * self.config.discount**i
+
+        return value
+
+    def make_target(self, game_history, state_index):
+        """
+        Generate targets for every unroll steps.
+        """
+        target_values, target_rewards, target_policies, actions = [], [], [], []
+        for current_index in range(
+            state_index, state_index + self.config.num_unroll_steps + 1
+        ):
+            value = self.compute_target_value(game_history, current_index)
+
+            if current_index < len(game_history.root_values):
+                target_values.append(value)
+                target_rewards.append(game_history.reward_history[current_index])
+                target_policies.append(game_history.child_visits[current_index])
+                actions.append(game_history.action_history[current_index])
+            elif current_index == len(game_history.root_values):
+                target_values.append(0)
+                target_rewards.append(game_history.reward_history[current_index])
+                # Uniform policy
+                target_policies.append(
+                    [
+                        1 / len(game_history.child_visits[0])
+                        for _ in range(len(game_history.child_visits[0]))
+                    ]
+                )
+                actions.append(game_history.action_history[current_index])
+            else:
+                # States past the end of games are treated as absorbing states
+                target_values.append(0)
+                target_rewards.append(0)
+                # Uniform policy
+                target_policies.append(
+                    [
+                        1 / len(game_history.child_visits[0])
+                        for _ in range(len(game_history.child_visits[0]))
+                    ]
+                )
+                actions.append(numpy.random.choice(self.config.action_space))
+
+        return target_values, target_rewards, target_policies, actions
+
+
+@ray.remote
+class Reanalyse:
+    """
+    Class which run in a dedicated thread to update the replay buffer with fresh information.
+    See paper appendix Reanalyse.
+    """
+
+    def __init__(self, initial_checkpoint, config):
+        self.config = config
+
+        # Fix random generator seed
+        numpy.random.seed(self.config.seed)
+        torch.manual_seed(self.config.seed)
+
+        # Initialize the network
+        self.model = models.MuZeroNetwork(self.config)
+        self.model.set_weights(initial_checkpoint["weights"])
+        self.model.to(torch.device("cuda" if self.config.reanalyse_on_gpu else "cpu"))
+        self.model.eval()
+
+        self.num_reanalysed_games = initial_checkpoint["num_reanalysed_games"]
+
+    def reanalyse(self, replay_buffer, shared_storage):
+        while ray.get(shared_storage.get_info.remote("num_played_games")) < 1:
+            time.sleep(0.1)
+
+        while ray.get(
+            shared_storage.get_info.remote("training_step")
+        ) < self.config.training_steps and not ray.get(
+            shared_storage.get_info.remote("terminate")
+        ):
+            self.model.set_weights(ray.get(shared_storage.get_info.remote("weights")))
+
+            game_id, game_history, _ = ray.get(
+                replay_buffer.sample_game.remote(force_uniform=True)
+            )
+
+            # Use the last model to provide a fresher, stable n-step value (See paper appendix Reanalyze)
+            if self.config.use_last_model_value:
+                observations = numpy.array(
+                    [
+                        game_history.get_stacked_observations(
+                            i,
+                            self.config.stacked_observations,
+                            len(self.config.action_space),
+                        )
+                        for i in range(len(game_history.root_values))
+                    ]
+                )
+
+                observations = (
+                    torch.tensor(observations)
+                    .float()
+                    .to(next(self.model.parameters()).device)
+                )
+                values = models.support_to_scalar(
+                    self.model.initial_inference(observations)[0],
+                    self.config.support_size,
+                )
+                game_history.reanalysed_predicted_root_values = (
+                    torch.squeeze(values).detach().cpu().numpy()
+                )
+
+            replay_buffer.update_game_history.remote(game_id, game_history)
+            self.num_reanalysed_games += 1
+            shared_storage.set_info.remote(
+                "num_reanalysed_games", self.num_reanalysed_games
+            )

--- a/muzero_general/self_play.py
+++ b/muzero_general/self_play.py
@@ -1,0 +1,570 @@
+import math
+import time
+
+import numpy
+import ray
+import torch
+
+import models
+
+
+@ray.remote
+class SelfPlay:
+    """
+    Class which run in a dedicated thread to play games and save them to the replay-buffer.
+    """
+
+    def __init__(self, initial_checkpoint, Game, config, seed):
+        self.config = config
+        self.game = Game(seed)
+
+        # Fix random generator seed
+        numpy.random.seed(seed)
+        torch.manual_seed(seed)
+
+        # Initialize the network
+        self.model = models.MuZeroNetwork(self.config)
+        self.model.set_weights(initial_checkpoint["weights"])
+        self.model.to(torch.device("cuda" if self.config.selfplay_on_gpu else "cpu"))
+        self.model.eval()
+
+    def continuous_self_play(self, shared_storage, replay_buffer, test_mode=False):
+        while ray.get(
+            shared_storage.get_info.remote("training_step")
+        ) < self.config.training_steps and not ray.get(
+            shared_storage.get_info.remote("terminate")
+        ):
+            self.model.set_weights(ray.get(shared_storage.get_info.remote("weights")))
+
+            if not test_mode:
+                game_history = self.play_game(
+                    self.config.visit_softmax_temperature_fn(
+                        trained_steps=ray.get(
+                            shared_storage.get_info.remote("training_step")
+                        )
+                    ),
+                    self.config.temperature_threshold,
+                    False,
+                    "self",
+                    0,
+                )
+
+                replay_buffer.save_game.remote(game_history, shared_storage)
+
+            else:
+                # Take the best action (no exploration) in test mode
+                game_history = self.play_game(
+                    0,
+                    self.config.temperature_threshold,
+                    False,
+                    "self" if len(self.config.players) == 1 else self.config.opponent,
+                    self.config.muzero_player,
+                )
+
+                # Save to the shared storage
+                shared_storage.set_info.remote(
+                    {
+                        "episode_length": len(game_history.action_history) - 1,
+                        "total_reward": sum(game_history.reward_history),
+                        "mean_value": numpy.mean(
+                            [value for value in game_history.root_values if value]
+                        ),
+                    }
+                )
+                if 1 < len(self.config.players):
+                    shared_storage.set_info.remote(
+                        {
+                            "muzero_reward": sum(
+                                reward
+                                for i, reward in enumerate(game_history.reward_history)
+                                if game_history.to_play_history[i - 1]
+                                == self.config.muzero_player
+                            ),
+                            "opponent_reward": sum(
+                                reward
+                                for i, reward in enumerate(game_history.reward_history)
+                                if game_history.to_play_history[i - 1]
+                                != self.config.muzero_player
+                            ),
+                        }
+                    )
+
+            # Managing the self-play / training ratio
+            if not test_mode and self.config.self_play_delay:
+                time.sleep(self.config.self_play_delay)
+            if not test_mode and self.config.ratio:
+                while (
+                    ray.get(shared_storage.get_info.remote("training_step"))
+                    / max(
+                        1, ray.get(shared_storage.get_info.remote("num_played_steps"))
+                    )
+                    < self.config.ratio
+                    and ray.get(shared_storage.get_info.remote("training_step"))
+                    < self.config.training_steps
+                    and not ray.get(shared_storage.get_info.remote("terminate"))
+                ):
+                    time.sleep(0.5)
+
+        self.close_game()
+
+    def play_game(
+        self, temperature, temperature_threshold, render, opponent, muzero_player
+    ):
+        """
+        Play one game with actions based on the Monte Carlo tree search at each moves.
+        """
+        game_history = GameHistory()
+        observation = self.game.reset()
+        game_history.action_history.append(0)
+        game_history.observation_history.append(observation)
+        game_history.reward_history.append(0)
+        game_history.to_play_history.append(self.game.to_play())
+
+        done = False
+
+        if render:
+            self.game.render()
+
+        with torch.no_grad():
+            while (
+                not done and len(game_history.action_history) <= self.config.max_moves
+            ):
+                assert (
+                    len(numpy.array(observation).shape) == 3
+                ), f"Observation should be 3 dimensionnal instead of {len(numpy.array(observation).shape)} dimensionnal. Got observation of shape: {numpy.array(observation).shape}"
+                assert (
+                    numpy.array(observation).shape == self.config.observation_shape
+                ), f"Observation should match the observation_shape defined in MuZeroConfig. Expected {self.config.observation_shape} but got {numpy.array(observation).shape}."
+                stacked_observations = game_history.get_stacked_observations(
+                    -1, self.config.stacked_observations, len(self.config.action_space)
+                )
+
+                # Choose the action
+                if opponent == "self" or muzero_player == self.game.to_play():
+                    root, mcts_info = MCTS(self.config).run(
+                        self.model,
+                        stacked_observations,
+                        self.game.legal_actions(),
+                        self.game.to_play(),
+                        True,
+                    )
+                    action = self.select_action(
+                        root,
+                        temperature
+                        if not temperature_threshold
+                        or len(game_history.action_history) < temperature_threshold
+                        else 0,
+                    )
+
+                    if render:
+                        print(f'Tree depth: {mcts_info["max_tree_depth"]}')
+                        print(
+                            f"Root value for player {self.game.to_play()}: {root.value():.2f}"
+                        )
+                else:
+                    action, root = self.select_opponent_action(
+                        opponent, stacked_observations
+                    )
+
+                observation, reward, done = self.game.step(action)
+
+                if render:
+                    print(f"Played action: {self.game.action_to_string(action)}")
+                    self.game.render()
+
+                game_history.store_search_statistics(root, self.config.action_space)
+
+                # Next batch
+                game_history.action_history.append(action)
+                game_history.observation_history.append(observation)
+                game_history.reward_history.append(reward)
+                game_history.to_play_history.append(self.game.to_play())
+
+        return game_history
+
+    def close_game(self):
+        self.game.close()
+
+    def select_opponent_action(self, opponent, stacked_observations):
+        """
+        Select opponent action for evaluating MuZero level.
+        """
+        if opponent == "human":
+            root, mcts_info = MCTS(self.config).run(
+                self.model,
+                stacked_observations,
+                self.game.legal_actions(),
+                self.game.to_play(),
+                True,
+            )
+            print(f'Tree depth: {mcts_info["max_tree_depth"]}')
+            print(f"Root value for player {self.game.to_play()}: {root.value():.2f}")
+            print(
+                f"Player {self.game.to_play()} turn. MuZero suggests {self.game.action_to_string(self.select_action(root, 0))}"
+            )
+            return self.game.human_to_action(), root
+        elif opponent == "expert":
+            return self.game.expert_agent(), None
+        elif opponent == "random":
+            assert (
+                self.game.legal_actions()
+            ), f"Legal actions should not be an empty array. Got {self.game.legal_actions()}."
+            assert set(self.game.legal_actions()).issubset(
+                set(self.config.action_space)
+            ), "Legal actions should be a subset of the action space."
+
+            return numpy.random.choice(self.game.legal_actions()), None
+        else:
+            raise NotImplementedError(
+                'Wrong argument: "opponent" argument should be "self", "human", "expert" or "random"'
+            )
+
+    @staticmethod
+    def select_action(node, temperature):
+        """
+        Select action according to the visit count distribution and the temperature.
+        The temperature is changed dynamically with the visit_softmax_temperature function
+        in the config.
+        """
+        visit_counts = numpy.array(
+            [child.visit_count for child in node.children.values()], dtype="int32"
+        )
+        actions = [action for action in node.children.keys()]
+        if temperature == 0:
+            action = actions[numpy.argmax(visit_counts)]
+        elif temperature == float("inf"):
+            action = numpy.random.choice(actions)
+        else:
+            # See paper appendix Data Generation
+            visit_count_distribution = visit_counts ** (1 / temperature)
+            visit_count_distribution = visit_count_distribution / sum(
+                visit_count_distribution
+            )
+            action = numpy.random.choice(actions, p=visit_count_distribution)
+
+        return action
+
+
+# Game independent
+class MCTS:
+    """
+    Core Monte Carlo Tree Search algorithm.
+    To decide on an action, we run N simulations, always starting at the root of
+    the search tree and traversing the tree according to the UCB formula until we
+    reach a leaf node.
+    """
+
+    def __init__(self, config):
+        self.config = config
+
+    def run(
+        self,
+        model,
+        observation,
+        legal_actions,
+        to_play,
+        add_exploration_noise,
+        override_root_with=None,
+    ):
+        """
+        At the root of the search tree we use the representation function to obtain a
+        hidden state given the current observation.
+        We then run a Monte Carlo Tree Search using only action sequences and the model
+        learned by the network.
+        """
+        if override_root_with:
+            root = override_root_with
+            root_predicted_value = None
+        else:
+            root = Node(0)
+            observation = (
+                torch.tensor(observation)
+                .float()
+                .unsqueeze(0)
+                .to(next(model.parameters()).device)
+            )
+            (
+                root_predicted_value,
+                reward,
+                policy_logits,
+                hidden_state,
+            ) = model.initial_inference(observation)
+            root_predicted_value = models.support_to_scalar(
+                root_predicted_value, self.config.support_size
+            ).item()
+            reward = models.support_to_scalar(reward, self.config.support_size).item()
+            assert (
+                legal_actions
+            ), f"Legal actions should not be an empty array. Got {legal_actions}."
+            assert set(legal_actions).issubset(
+                set(self.config.action_space)
+            ), "Legal actions should be a subset of the action space."
+            root.expand(
+                legal_actions,
+                to_play,
+                reward,
+                policy_logits,
+                hidden_state,
+            )
+
+        if add_exploration_noise:
+            root.add_exploration_noise(
+                dirichlet_alpha=self.config.root_dirichlet_alpha,
+                exploration_fraction=self.config.root_exploration_fraction,
+            )
+
+        min_max_stats = MinMaxStats()
+
+        max_tree_depth = 0
+        for _ in range(self.config.num_simulations):
+            virtual_to_play = to_play
+            node = root
+            search_path = [node]
+            current_tree_depth = 0
+
+            while node.expanded():
+                current_tree_depth += 1
+                action, node = self.select_child(node, min_max_stats)
+                search_path.append(node)
+
+                # Players play turn by turn
+                if virtual_to_play + 1 < len(self.config.players):
+                    virtual_to_play = self.config.players[virtual_to_play + 1]
+                else:
+                    virtual_to_play = self.config.players[0]
+
+            # Inside the search tree we use the dynamics function to obtain the next hidden
+            # state given an action and the previous hidden state
+            parent = search_path[-2]
+            value, reward, policy_logits, hidden_state = model.recurrent_inference(
+                parent.hidden_state,
+                torch.tensor([[action]]).to(parent.hidden_state.device),
+            )
+            value = models.support_to_scalar(value, self.config.support_size).item()
+            reward = models.support_to_scalar(reward, self.config.support_size).item()
+            node.expand(
+                self.config.action_space,
+                virtual_to_play,
+                reward,
+                policy_logits,
+                hidden_state,
+            )
+
+            self.backpropagate(search_path, value, virtual_to_play, min_max_stats)
+
+            max_tree_depth = max(max_tree_depth, current_tree_depth)
+
+        extra_info = {
+            "max_tree_depth": max_tree_depth,
+            "root_predicted_value": root_predicted_value,
+        }
+        return root, extra_info
+
+    def select_child(self, node, min_max_stats):
+        """
+        Select the child with the highest UCB score.
+        """
+        max_ucb = max(
+            self.ucb_score(node, child, min_max_stats)
+            for action, child in node.children.items()
+        )
+        action = numpy.random.choice(
+            [
+                action
+                for action, child in node.children.items()
+                if self.ucb_score(node, child, min_max_stats) == max_ucb
+            ]
+        )
+        return action, node.children[action]
+
+    def ucb_score(self, parent, child, min_max_stats):
+        """
+        The score for a node is based on its value, plus an exploration bonus based on the prior.
+        """
+        pb_c = (
+            math.log(
+                (parent.visit_count + self.config.pb_c_base + 1) / self.config.pb_c_base
+            )
+            + self.config.pb_c_init
+        )
+        pb_c *= math.sqrt(parent.visit_count) / (child.visit_count + 1)
+
+        prior_score = pb_c * child.prior
+
+        if child.visit_count > 0:
+            # Mean value Q
+            value_score = min_max_stats.normalize(
+                child.reward
+                + self.config.discount
+                * (child.value() if len(self.config.players) == 1 else -child.value())
+            )
+        else:
+            value_score = 0
+
+        return prior_score + value_score
+
+    def backpropagate(self, search_path, value, to_play, min_max_stats):
+        """
+        At the end of a simulation, we propagate the evaluation all the way up the tree
+        to the root.
+        """
+        if len(self.config.players) == 1:
+            for node in reversed(search_path):
+                node.value_sum += value
+                node.visit_count += 1
+                min_max_stats.update(node.reward + self.config.discount * node.value())
+
+                value = node.reward + self.config.discount * value
+
+        elif len(self.config.players) == 2:
+            for node in reversed(search_path):
+                node.value_sum += value if node.to_play == to_play else -value
+                node.visit_count += 1
+                min_max_stats.update(node.reward + self.config.discount * -node.value())
+
+                value = (
+                    -node.reward if node.to_play == to_play else node.reward
+                ) + self.config.discount * value
+
+        else:
+            raise NotImplementedError("More than two player mode not implemented.")
+
+
+class Node:
+    def __init__(self, prior):
+        self.visit_count = 0
+        self.to_play = -1
+        self.prior = prior
+        self.value_sum = 0
+        self.children = {}
+        self.hidden_state = None
+        self.reward = 0
+
+    def expanded(self):
+        return len(self.children) > 0
+
+    def value(self):
+        if self.visit_count == 0:
+            return 0
+        return self.value_sum / self.visit_count
+
+    def expand(self, actions, to_play, reward, policy_logits, hidden_state):
+        """
+        We expand a node using the value, reward and policy prediction obtained from the
+        neural network.
+        """
+        self.to_play = to_play
+        self.reward = reward
+        self.hidden_state = hidden_state
+
+        policy_values = torch.softmax(
+            torch.tensor([policy_logits[0][a] for a in actions]), dim=0
+        ).tolist()
+        policy = {a: policy_values[i] for i, a in enumerate(actions)}
+        for action, p in policy.items():
+            self.children[action] = Node(p)
+
+    def add_exploration_noise(self, dirichlet_alpha, exploration_fraction):
+        """
+        At the start of each search, we add dirichlet noise to the prior of the root to
+        encourage the search to explore new actions.
+        """
+        actions = list(self.children.keys())
+        noise = numpy.random.dirichlet([dirichlet_alpha] * len(actions))
+        frac = exploration_fraction
+        for a, n in zip(actions, noise):
+            self.children[a].prior = self.children[a].prior * (1 - frac) + n * frac
+
+
+class GameHistory:
+    """
+    Store only usefull information of a self-play game.
+    """
+
+    def __init__(self):
+        self.observation_history = []
+        self.action_history = []
+        self.reward_history = []
+        self.to_play_history = []
+        self.child_visits = []
+        self.root_values = []
+        self.reanalysed_predicted_root_values = None
+        # For PER
+        self.priorities = None
+        self.game_priority = None
+
+    def store_search_statistics(self, root, action_space):
+        # Turn visit count from root into a policy
+        if root is not None:
+            sum_visits = sum(child.visit_count for child in root.children.values())
+            self.child_visits.append(
+                [
+                    root.children[a].visit_count / sum_visits
+                    if a in root.children
+                    else 0
+                    for a in action_space
+                ]
+            )
+
+            self.root_values.append(root.value())
+        else:
+            self.root_values.append(None)
+
+    def get_stacked_observations(
+        self, index, num_stacked_observations, action_space_size
+    ):
+        """
+        Generate a new observation with the observation at the index position
+        and num_stacked_observations past observations and actions stacked.
+        """
+        # Convert to positive index
+        index = index % len(self.observation_history)
+
+        stacked_observations = self.observation_history[index].copy()
+        for past_observation_index in reversed(
+            range(index - num_stacked_observations, index)
+        ):
+            if 0 <= past_observation_index:
+                previous_observation = numpy.concatenate(
+                    (
+                        self.observation_history[past_observation_index],
+                        [
+                            numpy.ones_like(stacked_observations[0])
+                            * self.action_history[past_observation_index + 1]
+                            / action_space_size
+                        ],
+                    )
+                )
+            else:
+                previous_observation = numpy.concatenate(
+                    (
+                        numpy.zeros_like(self.observation_history[index]),
+                        [numpy.zeros_like(stacked_observations[0])],
+                    )
+                )
+
+            stacked_observations = numpy.concatenate(
+                (stacked_observations, previous_observation)
+            )
+
+        return stacked_observations
+
+
+class MinMaxStats:
+    """
+    A class that holds the min-max values of the tree.
+    """
+
+    def __init__(self):
+        self.maximum = -float("inf")
+        self.minimum = float("inf")
+
+    def update(self, value):
+        self.maximum = max(self.maximum, value)
+        self.minimum = min(self.minimum, value)
+
+    def normalize(self, value):
+        if self.maximum > self.minimum:
+            # We normalize only when we have set the maximum and minimum values
+            return (value - self.minimum) / (self.maximum - self.minimum)
+        return value

--- a/muzero_general/shared_storage.py
+++ b/muzero_general/shared_storage.py
@@ -1,0 +1,40 @@
+import copy
+
+import ray
+import torch
+
+
+@ray.remote
+class SharedStorage:
+    """
+    Class which run in a dedicated thread to store the network weights and some information.
+    """
+
+    def __init__(self, checkpoint, config):
+        self.config = config
+        self.current_checkpoint = copy.deepcopy(checkpoint)
+
+    def save_checkpoint(self, path=None):
+        if not path:
+            path = self.config.results_path / "model.checkpoint"
+
+        torch.save(self.current_checkpoint, path)
+
+    def get_checkpoint(self):
+        return copy.deepcopy(self.current_checkpoint)
+
+    def get_info(self, keys):
+        if isinstance(keys, str):
+            return self.current_checkpoint[keys]
+        elif isinstance(keys, list):
+            return {key: self.current_checkpoint[key] for key in keys}
+        else:
+            raise TypeError
+
+    def set_info(self, keys, values=None):
+        if isinstance(keys, str) and values is not None:
+            self.current_checkpoint[keys] = values
+        elif isinstance(keys, dict):
+            self.current_checkpoint.update(keys)
+        else:
+            raise TypeError

--- a/muzero_general/trainer.py
+++ b/muzero_general/trainer.py
@@ -1,0 +1,300 @@
+import copy
+import time
+
+import numpy
+import ray
+import torch
+
+import models
+
+
+@ray.remote
+class Trainer:
+    """
+    Class which run in a dedicated thread to train a neural network and save it
+    in the shared storage.
+    """
+
+    def __init__(self, initial_checkpoint, config):
+        self.config = config
+
+        # Fix random generator seed
+        numpy.random.seed(self.config.seed)
+        torch.manual_seed(self.config.seed)
+
+        # Initialize the network
+        self.model = models.MuZeroNetwork(self.config)
+        self.model.set_weights(copy.deepcopy(initial_checkpoint["weights"]))
+        self.model.to(torch.device("cuda" if self.config.train_on_gpu else "cpu"))
+        self.model.train()
+
+        self.training_step = initial_checkpoint["training_step"]
+
+        if "cuda" not in str(next(self.model.parameters()).device):
+            print("You are not training on GPU.\n")
+
+        # Initialize the optimizer
+        if self.config.optimizer == "SGD":
+            self.optimizer = torch.optim.SGD(
+                self.model.parameters(),
+                lr=self.config.lr_init,
+                momentum=self.config.momentum,
+                weight_decay=self.config.weight_decay,
+            )
+        elif self.config.optimizer == "Adam":
+            self.optimizer = torch.optim.Adam(
+                self.model.parameters(),
+                lr=self.config.lr_init,
+                weight_decay=self.config.weight_decay,
+            )
+        else:
+            raise NotImplementedError(
+                f"{self.config.optimizer} is not implemented. You can change the optimizer manually in trainer.py."
+            )
+
+        if initial_checkpoint["optimizer_state"] is not None:
+            print("Loading optimizer...\n")
+            self.optimizer.load_state_dict(
+                copy.deepcopy(initial_checkpoint["optimizer_state"])
+            )
+
+    def continuous_update_weights(self, replay_buffer, shared_storage):
+        # Wait for the replay buffer to be filled
+        while ray.get(shared_storage.get_info.remote("num_played_games")) < 1:
+            time.sleep(0.1)
+
+        next_batch = replay_buffer.get_batch.remote()
+        # Training loop
+        while self.training_step < self.config.training_steps and not ray.get(
+            shared_storage.get_info.remote("terminate")
+        ):
+            index_batch, batch = ray.get(next_batch)
+            next_batch = replay_buffer.get_batch.remote()
+            self.update_lr()
+            (
+                priorities,
+                total_loss,
+                value_loss,
+                reward_loss,
+                policy_loss,
+            ) = self.update_weights(batch)
+
+            if self.config.PER:
+                # Save new priorities in the replay buffer (See https://arxiv.org/abs/1803.00933)
+                replay_buffer.update_priorities.remote(priorities, index_batch)
+
+            # Save to the shared storage
+            if self.training_step % self.config.checkpoint_interval == 0:
+                shared_storage.set_info.remote(
+                    {
+                        "weights": copy.deepcopy(self.model.get_weights()),
+                        "optimizer_state": copy.deepcopy(
+                            models.dict_to_cpu(self.optimizer.state_dict())
+                        ),
+                    }
+                )
+                if self.config.save_model:
+                    shared_storage.save_checkpoint.remote()
+            shared_storage.set_info.remote(
+                {
+                    "training_step": self.training_step,
+                    "lr": self.optimizer.param_groups[0]["lr"],
+                    "total_loss": total_loss,
+                    "value_loss": value_loss,
+                    "reward_loss": reward_loss,
+                    "policy_loss": policy_loss,
+                }
+            )
+
+            # Managing the self-play / training ratio
+            if self.config.training_delay:
+                time.sleep(self.config.training_delay)
+            if self.config.ratio:
+                while (
+                    self.training_step
+                    / max(
+                        1, ray.get(shared_storage.get_info.remote("num_played_steps"))
+                    )
+                    > self.config.ratio
+                    and self.training_step < self.config.training_steps
+                    and not ray.get(shared_storage.get_info.remote("terminate"))
+                ):
+                    time.sleep(0.5)
+
+    def update_weights(self, batch):
+        """
+        Perform one training step.
+        """
+
+        (
+            observation_batch,
+            action_batch,
+            target_value,
+            target_reward,
+            target_policy,
+            weight_batch,
+            gradient_scale_batch,
+        ) = batch
+
+        # Keep values as scalars for calculating the priorities for the prioritized replay
+        target_value_scalar = numpy.array(target_value, dtype="float32")
+        priorities = numpy.zeros_like(target_value_scalar)
+
+        device = next(self.model.parameters()).device
+        if self.config.PER:
+            weight_batch = torch.tensor(weight_batch.copy()).float().to(device)
+        observation_batch = (
+            torch.tensor(numpy.array(observation_batch)).float().to(device)
+        )
+        action_batch = torch.tensor(action_batch).long().to(device).unsqueeze(-1)
+        target_value = torch.tensor(target_value).float().to(device)
+        target_reward = torch.tensor(target_reward).float().to(device)
+        target_policy = torch.tensor(target_policy).float().to(device)
+        gradient_scale_batch = torch.tensor(gradient_scale_batch).float().to(device)
+        # observation_batch: batch, channels, height, width
+        # action_batch: batch, num_unroll_steps+1, 1 (unsqueeze)
+        # target_value: batch, num_unroll_steps+1
+        # target_reward: batch, num_unroll_steps+1
+        # target_policy: batch, num_unroll_steps+1, len(action_space)
+        # gradient_scale_batch: batch, num_unroll_steps+1
+
+        target_value = models.scalar_to_support(target_value, self.config.support_size)
+        target_reward = models.scalar_to_support(
+            target_reward, self.config.support_size
+        )
+        # target_value: batch, num_unroll_steps+1, 2*support_size+1
+        # target_reward: batch, num_unroll_steps+1, 2*support_size+1
+
+        ## Generate predictions
+        value, reward, policy_logits, hidden_state = self.model.initial_inference(
+            observation_batch
+        )
+        predictions = [(value, reward, policy_logits)]
+        for i in range(1, action_batch.shape[1]):
+            value, reward, policy_logits, hidden_state = self.model.recurrent_inference(
+                hidden_state, action_batch[:, i]
+            )
+            # Scale the gradient at the start of the dynamics function (See paper appendix Training)
+            hidden_state.register_hook(lambda grad: grad * 0.5)
+            predictions.append((value, reward, policy_logits))
+        # predictions: num_unroll_steps+1, 3, batch, 2*support_size+1 | 2*support_size+1 | 9 (according to the 2nd dim)
+
+        ## Compute losses
+        value_loss, reward_loss, policy_loss = (0, 0, 0)
+        value, reward, policy_logits = predictions[0]
+        # Ignore reward loss for the first batch step
+        current_value_loss, _, current_policy_loss = self.loss_function(
+            value.squeeze(-1),
+            reward.squeeze(-1),
+            policy_logits,
+            target_value[:, 0],
+            target_reward[:, 0],
+            target_policy[:, 0],
+        )
+        value_loss += current_value_loss
+        policy_loss += current_policy_loss
+        # Compute priorities for the prioritized replay (See paper appendix Training)
+        pred_value_scalar = (
+            models.support_to_scalar(value, self.config.support_size)
+            .detach()
+            .cpu()
+            .numpy()
+            .squeeze()
+        )
+        priorities[:, 0] = (
+            numpy.abs(pred_value_scalar - target_value_scalar[:, 0])
+            ** self.config.PER_alpha
+        )
+
+        for i in range(1, len(predictions)):
+            value, reward, policy_logits = predictions[i]
+            (
+                current_value_loss,
+                current_reward_loss,
+                current_policy_loss,
+            ) = self.loss_function(
+                value.squeeze(-1),
+                reward.squeeze(-1),
+                policy_logits,
+                target_value[:, i],
+                target_reward[:, i],
+                target_policy[:, i],
+            )
+
+            # Scale gradient by the number of unroll steps (See paper appendix Training)
+            current_value_loss.register_hook(
+                lambda grad: grad / gradient_scale_batch[:, i]
+            )
+            current_reward_loss.register_hook(
+                lambda grad: grad / gradient_scale_batch[:, i]
+            )
+            current_policy_loss.register_hook(
+                lambda grad: grad / gradient_scale_batch[:, i]
+            )
+
+            value_loss += current_value_loss
+            reward_loss += current_reward_loss
+            policy_loss += current_policy_loss
+
+            # Compute priorities for the prioritized replay (See paper appendix Training)
+            pred_value_scalar = (
+                models.support_to_scalar(value, self.config.support_size)
+                .detach()
+                .cpu()
+                .numpy()
+                .squeeze()
+            )
+            priorities[:, i] = (
+                numpy.abs(pred_value_scalar - target_value_scalar[:, i])
+                ** self.config.PER_alpha
+            )
+
+        # Scale the value loss, paper recommends by 0.25 (See paper appendix Reanalyze)
+        loss = value_loss * self.config.value_loss_weight + reward_loss + policy_loss
+        if self.config.PER:
+            # Correct PER bias by using importance-sampling (IS) weights
+            loss *= weight_batch
+        # Mean over batch dimension (pseudocode do a sum)
+        loss = loss.mean()
+
+        # Optimize
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+        self.training_step += 1
+
+        return (
+            priorities,
+            # For log purpose
+            loss.item(),
+            value_loss.mean().item(),
+            reward_loss.mean().item(),
+            policy_loss.mean().item(),
+        )
+
+    def update_lr(self):
+        """
+        Update learning rate
+        """
+        lr = self.config.lr_init * self.config.lr_decay_rate ** (
+            self.training_step / self.config.lr_decay_steps
+        )
+        for param_group in self.optimizer.param_groups:
+            param_group["lr"] = lr
+
+    @staticmethod
+    def loss_function(
+        value,
+        reward,
+        policy_logits,
+        target_value,
+        target_reward,
+        target_policy,
+    ):
+        # Cross-entropy seems to have a better convergence than MSE
+        value_loss = (-target_value * torch.nn.LogSoftmax(dim=1)(value)).sum(1)
+        reward_loss = (-target_reward * torch.nn.LogSoftmax(dim=1)(reward)).sum(1)
+        policy_loss = (-target_policy * torch.nn.LogSoftmax(dim=1)(policy_logits)).sum(
+            1
+        )
+        return value_loss, reward_loss, policy_loss

--- a/run_stock_muzero.py
+++ b/run_stock_muzero.py
@@ -1,0 +1,5 @@
+from muzero_general.muzero import MuZero
+
+if __name__ == "__main__":
+    muzero = MuZero("stock_market")
+    muzero.train()


### PR DESCRIPTION
## Summary
- add script to download AAPL stock data via yfinance
- implement simple stock market environment for MuZero
- include minimal MuZero components to run training
- provide a short launcher script for training

## Testing
- `python data_loader.py`
- `PYTHONPATH=./:. python run_stock_muzero.py` (fails due to missing module; training requires further configuration)


------
https://chatgpt.com/codex/tasks/task_e_6885035eeb5c83268532c2c6b4ddfd92